### PR TITLE
CLA0003-1047 - wkhtmltopdf update

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,7 @@ AllCops:
     - test/**/*
     - vendor/**/*
     - ruby/**/*
+    - Vagrantfile
 
 AlignParameters:
   Enabled: false
@@ -19,3 +20,5 @@ LineLength:
   Enabled: false
 MethodLength:
   Max: 30
+Style/FrozenStringLiteralComment:
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 bundler_args: --without integration
 rvm:
-  - 2.2.0
+  - 2.2.2
 before_script:
   - bundle exec berks install
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 bundler_args: --without integration
 rvm:
-  - 2.2.2
+  - 2.4.2
 before_script:
   - bundle exec berks install
 script:

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,2 @@
-site :opscode
-
+source 'https://supermarket.chef.io'
 metadata

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.5.1
+
+* Removed the unused and deprecated `replaces` keyword from the metadata.rb
+* Updated the README to use 0.a.x instead of each version.
+* Fixed another foodcritic issue. This may break actual installation?
+
 ## 0.5.0
 
 * Updated the mirror URL to use github.com/wmkhtmltopdf/wkhtmltopdf/releases/downlaod

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.5.0
+
+* Updated the mirror URL to use github.com/wmkhtmltopdf/wkhtmltopdf/releases/downlaod
+* Updated the install packages to include x11-dev, zlib1g-dev, libfreetype6-dev (for debian based, need fedora, rhel, centos testing)
+* Added Ubuntu 16.04
+* Updated Gems
+* Updated Berksfile to source to reflect preferred method by Chef
+* Updated Travis RVM to 2.4.2
+* Updated Rubocop to exclude Vagrantfile and added FrozenStringLiterals
+
 ## 0.4.3
 
 * Update the mirror URL to use downloads.wkhtmltopdf.org instead of gna.org

--- a/Gemfile
+++ b/Gemfile
@@ -4,13 +4,13 @@ gem 'rake'
 gem 'stove'
 
 group :test, :integration do
-  gem 'berkshelf', '~> 2.0.14'
+  gem 'berkshelf', '~> 6.3.1'
 end
 
 group :test do
-  gem 'chefspec', '~> 4.0'
-  gem 'foodcritic', '~> 3.0.3'
-  gem 'rubocop', '~> 0.23'
+  gem 'chefspec', '~> 7.1.0'
+  gem 'foodcritic', '~> 11.4.0'
+  gem 'rubocop', '~> 0.50.0'
 end
 
 group :integration do

--- a/Guardfile
+++ b/Guardfile
@@ -1,7 +1,6 @@
 # A sample Guardfile
 # More info at https://github.com/guard/guard#readme
 
-# rubocop:disable RegexpLiteral
 guard 'kitchen' do
   watch(%r{test/.+})
   watch(%r{^recipes/(.+)\.rb$})
@@ -11,4 +10,3 @@ guard 'kitchen' do
   watch(%r{^providers/(.+)\.rb})
   watch(%r{^resources/(.+)\.rb})
 end
-# rubocop:enable RegexpLiteral

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Cookbook Compatibility:
  * chef-wkhtmltopdf 0.4.0: wkhtmltopdf 0.12.2.1
  * chef-wkhtmltopdf 0.4.1: wkhtmltopdf 0.12.2.1
  * chef-wkhtmltopdf 0.4.2: wkhtmltopdf 0.12.2.1
+ * chef-wkhtmltopdf 0.4.3: wkhtmltopdf 0.12.2.1
 
 ## Requirements
 
@@ -75,7 +76,7 @@ Please use standard Github issues/pull requests and if possible, in combination 
 ## Maintainers
 
 * Brian Flad (<bflad417@gmail.com>) [Deprecated ... He's no longer maintaining or merging pull requests. Decided to fork and start fresh.]
-* Jarvis Stubblefield (jarvis@vortexrevolutions.com)
+* Jarvis Stubblefield (jarvis@vortexrevolutions.com) Twitter: @BallisticPain
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,8 @@ Cookbook Compatibility:
 
  * chef-wkhtmltopdf 0.3.0: wkhtmltopdf 0.12.2
  * chef-wkhtmltopdf 0.3.1: wkhtmltopdf 0.12.2.1
- * chef-wkhtmltopdf 0.4.0: wkhtmltopdf 0.12.2.1
- * chef-wkhtmltopdf 0.4.1: wkhtmltopdf 0.12.2.1
- * chef-wkhtmltopdf 0.4.2: wkhtmltopdf 0.12.2.1
- * chef-wkhtmltopdf 0.4.3: wkhtmltopdf 0.12.2.1
- * chef-wkhtmltopdf 0.5.0: wkhtmltopdf 0.12.4
+ * chef-wkhtmltopdf 0.4.x: wkhtmltopdf 0.12.2.1
+ * chef-wkhtmltopdf 0.5.x: wkhtmltopdf 0.12.4
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Cookbook Compatibility:
  * chef-wkhtmltopdf 0.4.1: wkhtmltopdf 0.12.2.1
  * chef-wkhtmltopdf 0.4.2: wkhtmltopdf 0.12.2.1
  * chef-wkhtmltopdf 0.4.3: wkhtmltopdf 0.12.2.1
+ * chef-wkhtmltopdf 0.5.0: wkhtmltopdf 0.12.4
 
 ## Requirements
 
@@ -23,6 +24,7 @@ Cookbook Compatibility:
 * Ubuntu 13.04
 * Ubuntu 14.04
 * Ubuntu 14.10
+* Ubuntu 16.04
 
 ### Cookbooks
 
@@ -41,7 +43,7 @@ install_dir | directory to install static binaries | String | /usr/local/bin
 lib_dir | directory to install libraries | String | ''
 mirror_url | URL for wkhtmltopdf | String | (auto-detected, see attributes/default.rb)
 platform | wkhtmltopdf platform and architecture | String | (auto-detected, see attributes/default.rb)
-version | wkhtmltopdf version to install | String | 0.12.2.1
+version | wkhtmltopdf version to install | String | 0.12.4
 
 ## Recipes
 
@@ -61,7 +63,7 @@ Here's how you can quickly get testing or developing against the cookbook thanks
     vagrant plugin install vagrant-omnibus
     git clone git://github.com/ballisticpain/chef-wkhtmltopdf.git
     cd chef-wkhtmltopdf
-    vagrant up BOX # BOX being centos5, centos6, debian7, fedora18, fedora19, fedora20, freebsd9, ubuntu1204, ubuntu1210, ubuntu1304, ubuntu1310, ubuntu1404, or ubuntu1410
+    vagrant up BOX # BOX being centos5, centos6, debian7, fedora18, fedora19, fedora20, freebsd9, ubuntu1204, ubuntu1210, ubuntu1304, ubuntu1310, ubuntu1404, ubuntu1410, or ubuntu1604
 
 You can then SSH into the running VM using the `vagrant ssh BOX` command.
 

--- a/Rakefile
+++ b/Rakefile
@@ -58,7 +58,7 @@ end
 task unit: ['unit:rspec']
 
 desc 'Run all tests on Travis'
-task travis: %w(style unit)
+task travis: %w[style unit]
 
 # Default
 task default: ['style', 'unit', 'integration:kitchen:all']

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -92,6 +92,16 @@ Vagrant.configure('2') do |config|
         override.vm.box_url = "https://vagrantcloud.com/parallels/boxes/ubuntu-14.10"
     end
   end
+  
+  config.vm.define :ubuntu1604 do |ubuntu1604|
+    ubuntu1604.vm.box      = 'opscode-ubuntu-16.04'
+    ubuntu1604.vm.box_url  = 'http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-16.04_chef-provisionerless.box'
+    ubuntu1604.vm.hostname = "#{cookbook}-ubuntu-1604"
+	config.vm.provider "parallels" do |v, override|
+        override.vm.box = "parallels/ubuntu-16.04"
+        override.vm.box_url = "https://vagrantcloud.com/parallels/boxes/ubuntu-16.04"
+    end
+  end
 
   config.vm.network :private_network, ip: '192.168.50.10'
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -33,14 +33,14 @@ else
   if node['kernel']['machine'] == 'x86_64'
     default['wkhtmltopdf-update']['platform'] = 'linux-amd64'
     default['wkhtmltopdf-update']['package'] = value_for_platform_family(
-      %w(debian) => "wkhtmltox-#{node['wkhtmltopdf-update']['version']}.trusty-amd64.deb",
-      %w(fedora rhel) => "wkhtmltox-#{node['wkhtmltopdf-update']['version']}.centos6-amd64.rpm"
+      %w(debian) => "wkhtmltox_#{node['wkhtmltopdf-update']['version']}.trusty_amd64.deb",
+      %w(fedora rhel) => "wkhtmltox_#{node['wkhtmltopdf-update']['version']}.centos6_amd64.rpm"
     )
   else
     default['wkhtmltopdf-update']['platform'] = 'linux-i386'
     default['wkhtmltopdf-update']['package'] = value_for_platform_family(
-      %w(debian) => "wkhtmltox-#{node['wkhtmltopdf-update']['version']}.trusty-i386.deb",
-      %w(fedora rhel) => "wkhtmltox-#{node['wkhtmltopdf-update']['version']}.centos6-i386.rpm")
+      %w(debian) => "wkhtmltox_#{node['wkhtmltopdf-update']['version']}.trusty_i386.deb",
+      %w(fedora rhel) => "wkhtmltox_#{node['wkhtmltopdf-update']['version']}.centos6_i386.rpm")
   end
 
 end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,7 +5,7 @@ default['wkhtmltopdf']['lib_dir']     = ''
 
 default['wkhtmltopdf-update']['install_dir'] = '/usr/local/bin'
 default['wkhtmltopdf-update']['lib_dir']     = ''
-default['wkhtmltopdf-update']['version'] = '0.12.4'
+default['wkhtmltopdf-update']['version'] = '0.12.5'
 
 case node['platform_family']
 when 'mac_os_x', 'mac_os_x_server'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,7 +5,7 @@ default['wkhtmltopdf']['lib_dir']     = ''
 
 default['wkhtmltopdf-update']['install_dir'] = '/usr/local/bin'
 default['wkhtmltopdf-update']['lib_dir']     = ''
-default['wkhtmltopdf-update']['version'] = '0.12.5'
+default['wkhtmltopdf-update']['version'] = '0.12.5-1'
 
 case node['platform_family']
 when 'mac_os_x', 'mac_os_x_server'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,38 +3,33 @@ default['wkhtmltopdf']['version']     = '0.12.0'
 default['wkhtmltopdf']['install_dir'] = '/usr/local/bin'
 default['wkhtmltopdf']['lib_dir']     = ''
 
-default['wkhtmltopdf-update']['major_version'] = '0.12'
-default['wkhtmltopdf-update']['version'] = '0.12.2.1'
+default['wkhtmltopdf-update']['install_dir'] = '/usr/local/bin'
+default['wkhtmltopdf-update']['lib_dir']     = ''
+default['wkhtmltopdf-update']['version'] = '0.12.4'
 
 case node['platform_family']
 when 'mac_os_x', 'mac_os_x_server'
   default['wkhtmltopdf-update']['dependency_packages'] = []
-  default['wkhtmltopdf-update']['platform'] = 'macosx-10.9.1-x86_64'
+  default['wkhtmltopdf-update']['platform'] = 'osx-cocoa-x86-64.pkg'
 when 'windows'
   default['wkhtmltopdf-update']['dependency_packages'] = []
-  if node['kernel']['machine'] == 'x86_64'
-    default['wkhtmltopdf-update']['platform'] = 'win64'
-  else
-    default['wkhtmltopdf-update']['platform'] = 'win32'
-  end
+  default['wkhtmltopdf-update']['platform'] = if node['kernel']['machine'] == 'x86_64'
+                                                'msvc2015-win64.exe'
+                                              else
+                                                'msvc2015-win32.exe'
+                                              end
 else
   default['wkhtmltopdf-update']['dependency_packages'] = value_for_platform_family(
-    %w(debian) => %w(libfontconfig1 libssl0.9.8 libxext6 libxrender1 fontconfig libjpeg8 xfonts-base xfonts-75dpi),
-    %w(fedora rhel) => %w(fontconfig libXext libXrender openssl-devel urw-fonts)
+    %w[debian] => %w[zlib1g-dev libfontconfig1 libfreetype6-dev libxext6 libx11-dev libxrender1 fontconfig libjpeg8 xfonts-base xfonts-75dpi],
+    %w[fedora rhel] => %w[fontconfig libXext libXrender openssl-devel urw-fonts]
   )
-  if node['kernel']['machine'] == 'x86_64'
-    default['wkhtmltopdf-update']['platform'] = 'linux-amd64'
-    default['wkhtmltopdf-update']['package'] = value_for_platform_family(
-      %w(debian) => "wkhtmltox-#{node['wkhtmltopdf-update']['version']}_linux-trusty-amd64.deb",
-      %w(fedora rhel) => "wkhtmltox-#{node['wkhtmltopdf-update']['version']}_linux-centos6-amd64.rpm"
-    )
-  else
-    default['wkhtmltopdf-update']['platform'] = 'linux-i386'
-    default['wkhtmltopdf-update']['package'] = value_for_platform_family(
-      %w(debian) => "wkhtmltox-#{node['wkhtmltopdf-update']['version']}_linux-trusty-i386.deb",
-      %w(fedora rhel) => "wkhtmltox-#{node['wkhtmltopdf-update']['version']}_linux-centos6-i386.rpm")
-  end
+  default['wkhtmltopdf-update']['platform'] = if node['kernel']['machine'] == 'x86_64'
+                                                'linux-generic-amd64.tar.xz'
+                                              else
+                                                'linux-generic-i386.tar.xz'
+                                              end
 end
 
-default['wkhtmltopdf-update']['mirror_url'] = "https://downloads.wkhtmltopdf.org/#{node['wkhtmltopdf-update']['major_version']}/#{node['wkhtmltopdf-update']['version']}/#{node['wkhtmltopdf-update']['package']}"
+default['wkhtmltopdf-update']['archive'] = "wkhtmltox-#{node['wkhtmltopdf-update']['version']}_#{node['wkhtmltopdf-update']['platform']}"
+default['wkhtmltopdf-update']['mirror_url'] = "https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/#{node['wkhtmltopdf-update']['version']}/#{node['wkhtmltopdf-update']['archive']}"
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,6 +5,7 @@ default['wkhtmltopdf']['lib_dir']     = ''
 
 default['wkhtmltopdf-update']['install_dir'] = '/usr/local/bin'
 default['wkhtmltopdf-update']['lib_dir']     = ''
+default['wkhtmltopdf-update']['major_version'] = '0.12.5'
 default['wkhtmltopdf-update']['version'] = '0.12.5-1'
 
 case node['platform_family']
@@ -45,4 +46,4 @@ else
 
 end
 
-default['wkhtmltopdf-update']['mirror_url'] = "https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/#{node['wkhtmltopdf-update']['version']}/#{node['wkhtmltopdf-update']['package']}"
+default['wkhtmltopdf-update']['mirror_url'] = "https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/#{node['wkhtmltopdf-update']['major_version']}/#{node['wkhtmltopdf-update']['package']}"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,26 +10,39 @@ default['wkhtmltopdf-update']['version'] = '0.12.4'
 case node['platform_family']
 when 'mac_os_x', 'mac_os_x_server'
   default['wkhtmltopdf-update']['dependency_packages'] = []
-  default['wkhtmltopdf-update']['platform'] = 'osx-cocoa-x86-64.pkg'
+  default['wkhtmltopdf-update']['platform'] = 'macosx-10.9.1-x86_64'
+  default['wkhtmltopdf-update']['package'] = 'osx-cocoa-x86-64.pkg'
 when 'windows'
   default['wkhtmltopdf-update']['dependency_packages'] = []
   default['wkhtmltopdf-update']['platform'] = if node['kernel']['machine'] == 'x86_64'
-                                                'msvc2015-win64.exe'
+                                                'win64'
                                               else
-                                                'msvc2015-win32.exe'
+                                                'win32'
                                               end
+  default['wkhtmltopdf-update']['package'] = if node['kernel']['machine'] == 'x86_64'
+    'msvc2015-win64.exe'
+  else
+    'msvc2015-win32.exe'
+  end
 else
   default['wkhtmltopdf-update']['dependency_packages'] = value_for_platform_family(
     %w[debian] => %w[zlib1g-dev libfontconfig1 libfreetype6-dev libxext6 libx11-dev libxrender1 fontconfig libjpeg8 xfonts-base xfonts-75dpi],
     %w[fedora rhel] => %w[fontconfig libXext libXrender openssl-devel urw-fonts]
   )
-  default['wkhtmltopdf-update']['platform'] = if node['kernel']['machine'] == 'x86_64'
-                                                'linux-generic-amd64.tar.xz'
-                                              else
-                                                'linux-generic-i386.tar.xz'
-                                              end
+
+  if node['kernel']['machine'] == 'x86_64'
+    default['wkhtmltopdf-update']['platform'] = 'linux-amd64'
+    default['wkhtmltopdf-update']['package'] = value_for_platform_family(
+      %w(debian) => "wkhtmltox-#{node['wkhtmltopdf-update']['version']}.trusty-amd64.deb",
+      %w(fedora rhel) => "wkhtmltox-#{node['wkhtmltopdf-update']['version']}.centos6-amd64.rpm"
+    )
+  else
+    default['wkhtmltopdf-update']['platform'] = 'linux-i386'
+    default['wkhtmltopdf-update']['package'] = value_for_platform_family(
+      %w(debian) => "wkhtmltox-#{node['wkhtmltopdf-update']['version']}.trusty-i386.deb",
+      %w(fedora rhel) => "wkhtmltox-#{node['wkhtmltopdf-update']['version']}.centos6-i386.rpm")
+  end
+
 end
 
-default['wkhtmltopdf-update']['archive'] = "wkhtmltox-#{node['wkhtmltopdf-update']['version']}_#{node['wkhtmltopdf-update']['platform']}"
-default['wkhtmltopdf-update']['mirror_url'] = "https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/#{node['wkhtmltopdf-update']['version']}/#{node['wkhtmltopdf-update']['archive']}"
-
+default['wkhtmltopdf-update']['mirror_url'] = "https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/#{node['wkhtmltopdf-update']['version']}/#{node['wkhtmltopdf-update']['package']}"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,15 +4,13 @@ maintainer_email 'jarvis@vortexrevolutions.com'
 license 'Apache-2.0'
 description 'Installs wkhtmltoimage and wkhtmltopdf'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.5.0'
+version '0.5.1'
 chef_version '>= 12.0'
 source_url 'https://github.com/ballisticpain/chef-wkhtmltopdf'
 issues_url 'https://github.com/ballisticpain/chef-wkhtmltopdf/issues'
 
 recipe 'wkhtmltopdf-update', 'Installs the latest wkhtmltoimage and wkhtmltopdf'
 recipe 'wkhtmltopdf-update::binary', 'Installs the latest wkhtmltoimage and wkhtmltopdf binaries'
-
-replaces 'wkhtmltopdf'
 
 supports 'amazon'
 supports 'centos'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jarvis@vortexrevolutions.com'
 license 'Apache-2.0'
 description 'Installs wkhtmltoimage and wkhtmltopdf'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.5.1'
+version '0.5.2'
 chef_version '>= 12.0'
 source_url 'https://github.com/ballisticpain/chef-wkhtmltopdf'
 issues_url 'https://github.com/ballisticpain/chef-wkhtmltopdf/issues'

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,10 +1,13 @@
 name 'wkhtmltopdf-update'
 maintainer 'Jarvis Stubblefield'
 maintainer_email 'jarvis@vortexrevolutions.com'
-license 'Apache 2.0'
+license 'Apache-2.0'
 description 'Installs wkhtmltoimage and wkhtmltopdf'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.4.3'
+version '0.5.0'
+chef_version '>= 12.0'
+source_url 'https://github.com/ballisticpain/chef-wkhtmltopdf'
+issues_url 'https://github.com/ballisticpain/chef-wkhtmltopdf/issues'
 
 recipe 'wkhtmltopdf-update', 'Installs the latest wkhtmltoimage and wkhtmltopdf'
 recipe 'wkhtmltopdf-update::binary', 'Installs the latest wkhtmltoimage and wkhtmltopdf binaries'

--- a/recipes/binary.rb
+++ b/recipes/binary.rb
@@ -11,9 +11,9 @@ package 'wkhtmltopdf' do
   source download_dest
   not_if "/usr/local/bin/wkhtmltopdf --version | grep #{node['wkhtmltopdf-update']['version']}"
 
-  # if source.end_with?('.deb')
-  #   provider Chef::Provider::Package::Dpkg
-  # elsif source.end_with?('.rpm')
-  #   provider Chef::Provider::Package::Rpm
-  # end
+  if source.end_with?('.deb')
+    provider Chef::Provider::Package::Dpkg
+  elsif source.end_with?('.rpm')
+    provider Chef::Provider::Package::Rpm
+  end
 end

--- a/recipes/binary.rb
+++ b/recipes/binary.rb
@@ -3,7 +3,7 @@ download_dest = File.join(cache_dir, node['wkhtmltopdf-update']['package'])
 
 remote_file download_dest do
   source node['wkhtmltopdf-update']['mirror_url']
-  mode '0644'
+  mode '0777'
   action :create_if_missing
 end
 

--- a/recipes/binary.rb
+++ b/recipes/binary.rb
@@ -11,9 +11,9 @@ package 'wkhtmltopdf' do
   source download_dest
   not_if "/usr/local/bin/wkhtmltopdf --version | grep #{node['wkhtmltopdf-update']['version']}"
 
-  if source.end_with?('.deb')
-    provider Chef::Provider::Package::Dpkg
-  elsif source.end_with?('.rpm')
-    provider Chef::Provider::Package::Rpm
-  end
+  # if source.end_with?('.deb')
+  #   provider Chef::Provider::Package::Dpkg
+  # elsif source.end_with?('.rpm')
+  #   provider Chef::Provider::Package::Rpm
+  # end
 end

--- a/recipes/binary.rb
+++ b/recipes/binary.rb
@@ -10,7 +10,7 @@ end
 package 'wkhtmltopdf' do
   source download_dest
   not_if "/usr/local/bin/wkhtmltopdf --version | grep #{node['wkhtmltopdf-update']['version']}"
-
+  action :upgrade
   if source.end_with?('.deb')
     provider Chef::Provider::Package::Dpkg
   elsif source.end_with?('.rpm')


### PR DESCRIPTION
Brought in the latest master from BallisticPain and then made amendments for the latest download location and structure, and resolved the binary recipe.

This will install 0.12.5 now.

It downloads from https://github.com/wkhtmltopdf/wkhtmltopdf/releases/