### PR TITLE
Ubuntu codename urls

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -34,13 +34,13 @@ else
   if node['kernel']['machine'] == 'x86_64'
     default['wkhtmltopdf-update']['platform'] = 'linux-amd64'
     default['wkhtmltopdf-update']['package'] = value_for_platform_family(
-      %w(debian) => "wkhtmltox_#{node['wkhtmltopdf-update']['version']}.trusty_amd64.deb",
+      %w(debian) => "wkhtmltox_#{node['wkhtmltopdf-update']['version']}.#{node['lsb']['codename']}_amd64.deb",
       %w(fedora rhel) => "wkhtmltox_#{node['wkhtmltopdf-update']['version']}.centos6_amd64.rpm"
     )
   else
     default['wkhtmltopdf-update']['platform'] = 'linux-i386'
     default['wkhtmltopdf-update']['package'] = value_for_platform_family(
-      %w(debian) => "wkhtmltox_#{node['wkhtmltopdf-update']['version']}.trusty_i386.deb",
+      %w(debian) => "wkhtmltox_#{node['wkhtmltopdf-update']['version']}.#{node['lsb']['codename']}_i386.deb",
       %w(fedora rhel) => "wkhtmltox_#{node['wkhtmltopdf-update']['version']}.centos6_i386.rpm")
   end
 

--- a/recipes/binary.rb
+++ b/recipes/binary.rb
@@ -7,7 +7,7 @@ remote_file download_dest do
   action :create_if_missing
 end
 
-Array(node['wkhtmltopdf-update']['dependency_packages']).each do |package_name|
+Array(node['wkhtmltopdf-update']['dependency_packages']).each_with_index do |package_name, index|
   package package_name do
     action :install
   end

--- a/recipes/binary.rb
+++ b/recipes/binary.rb
@@ -7,12 +7,6 @@ remote_file download_dest do
   action :create_if_missing
 end
 
-Array(node['wkhtmltopdf-update']['dependency_packages']).each_with_index do |package_name, index|
-  package package_name do
-    action :install
-  end
-end
-
 package 'wkhtmltopdf' do
   source download_dest
   not_if "/usr/local/bin/wkhtmltopdf --version | grep #{node['wkhtmltopdf-update']['version']}"

--- a/recipes/binary.rb
+++ b/recipes/binary.rb
@@ -7,15 +7,16 @@ remote_file download_dest do
   action :create_if_missing
 end
 
+Array(node['wkhtmltopdf-update']['dependency_packages']).each do |package_name|
+  package package_name do
+    action :install
+  end
+end
+
 package 'wkhtmltopdf' do
   source download_dest
   not_if "/usr/local/bin/wkhtmltopdf --version | grep #{node['wkhtmltopdf-update']['version']}"
   action :upgrade
-  Array(node['wkhtmltopdf-update']['dependency_packages']).each_with_index do |package_name, index|
-    package package_name do
-      action :install
-    end
-  end
   if source.end_with?('.deb')
     provider Chef::Provider::Package::Dpkg
   elsif source.end_with?('.rpm')

--- a/recipes/binary.rb
+++ b/recipes/binary.rb
@@ -11,6 +11,11 @@ package 'wkhtmltopdf' do
   source download_dest
   not_if "/usr/local/bin/wkhtmltopdf --version | grep #{node['wkhtmltopdf-update']['version']}"
   action :upgrade
+  Array(node['wkhtmltopdf-update']['dependency_packages']).each_with_index do |package_name, index|
+    package package_name do
+      action :install
+    end
+  end
   if source.end_with?('.deb')
     provider Chef::Provider::Package::Dpkg
   elsif source.end_with?('.rpm')


### PR DESCRIPTION
When downloading the `.deb` file, make sure we get the version that corresponds to the Ubuntu version being run.